### PR TITLE
make relative autoload path absolute

### DIFF
--- a/src/generate.php
+++ b/src/generate.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace JohnBillion\WPHooksGenerator;
 
-require_once 'vendor/autoload.php';
+require_once file_exists( 'vendor/autoload.php' ) ? 'vendor/autoload.php' : dirname( __DIR__, 4 ) . '/vendor/autoload.php';
 
 $options = getopt( '', [
 	"input:",

--- a/src/validate.php
+++ b/src/validate.php
@@ -3,7 +3,7 @@
 
 namespace JohnBillion\WPHooksGenerator;
 
-require_once 'vendor/autoload.php';
+require_once file_exists( 'vendor/autoload.php' ) ? 'vendor/autoload.php' : dirname( __DIR__, 4 ) . '/vendor/autoload.php';
 
 use Opis\JsonSchema\{
 	Validator, ValidationResult, ValidationError, Schema


### PR DESCRIPTION
fix that it doesnt work when running from a different directory than where it's installed