### PR TITLE
skip file if it's non readable

### DIFF
--- a/src/generate.php
+++ b/src/generate.php
@@ -103,6 +103,9 @@ function hooks_parse_files( array $files, string $root, array $ignore_hooks ) : 
 	$output = array();
 
 	foreach ( $files as $filename ) {
+		if ( !is_readable( $filename ) ) {
+			continue;
+		}
 		$file = new \WP_Parser\File_Reflector( $filename );
 		$file_hooks = [];
 		$path = ltrim( substr( $filename, strlen( $root ) ), DIRECTORY_SEPARATOR );


### PR DESCRIPTION
Reflector gives an error "The given file should be a string, should exist on the filesystem and should be readable" if the file is not readable.

This seems to be an issue with what is going on in the background with the old version of reflector used here, as I did not encounter this issue with other libraries or the latest version of reflector when I run (e.g. psalm) on same files.
This just snoozes the error.