### PR TITLE
Support for aliases

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
 	],
 	"require": {
 		"php": ">=7",
+		"ext-libxml": "*",
 		"johnbillion/wp-parser-lib": "^1.3.0"
 	},
 	"require-dev": {

--- a/interface/index.d.ts
+++ b/interface/index.d.ts
@@ -33,6 +33,10 @@ export interface Hook {
    */
   name: string;
   /**
+   * Aliases of the hook name
+   */
+  aliases?: string[];
+  /**
    * The relative name of the file containing the hook
    */
   file: string;

--- a/schema.json
+++ b/schema.json
@@ -41,6 +41,13 @@
 							"init"
 						]
 					},
+					"aliases": {
+						"description": "Aliases of the hook name",
+						"type": "array",
+						"items": {
+							"type": "string"
+						}
+					},
 					"file": {
 						"description": "The relative name of the file containing the hook",
 						"type": "string",


### PR DESCRIPTION
Fixes https://github.com/johnbillion/wp-hooks/issues/6.

Unfortunately a specific PHPDoc tag never got implemented to document the common values for dynamic hook names, but we have now got a mostly standardised use of "Possible hook names include:" followed by an unordered list (example: https://developer.wordpress.org/reference/hooks/type_template_hierarchy/), so we can parse that list if it exists and store the result in a new property.

I've hooked up the resulting aliases to the autocomplete and hover provision in [WordPress Hooks Intellisense for VS Code](https://marketplace.visualstudio.com/items?itemName=johnbillion.vscode-wordpress-hooks):

<img width="923" alt="" src="https://user-images.githubusercontent.com/208434/171868336-fbf7caa3-d4f9-427c-993f-7a6bd2c20d10.png">
