### PR TITLE
New implementation of the hooks generation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
 		"ext-libxml": "*",
 		"erusev/parsedown": "^1.7",
 		"nikic/php-parser": "~4.0",
-		"phpdocumentor/reflection-docblock": "~5.0"
+		"phpdocumentor/reflection-docblock": "5.5.1"
 	},
 	"require-dev": {
 		"oomphinc/composer-installers-extender": "^2",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,9 @@
 	"require": {
 		"php": ">=7",
 		"ext-libxml": "*",
-		"johnbillion/wp-parser-lib": "^1.3.0"
+		"erusev/parsedown": "^1.7",
+		"nikic/php-parser": "~4.0",
+		"phpdocumentor/reflection-docblock": "~5.0"
 	},
 	"require-dev": {
 		"oomphinc/composer-installers-extender": "^2",

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
 	"require": {
 		"php": ">=7",
 		"ext-libxml": "*",
-		"erusev/parsedown": "^1.7",
-		"nikic/php-parser": "~4.0",
+		"erusev/parsedown": "1.8.0-beta-7",
+		"nikic/php-parser": "4.19.4",
 		"phpdocumentor/reflection-docblock": "5.5.1"
 	},
 	"require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
 		"bin/wp-hooks-generator"
 	],
 	"require": {
-		"php": ">=7",
+		"php": ">=7.4",
 		"ext-libxml": "*",
 		"erusev/parsedown": "1.8.0-beta-7",
 		"nikic/php-parser": "4.19.4",

--- a/composer.json
+++ b/composer.json
@@ -20,10 +20,10 @@
 		"bin/wp-hooks-generator"
 	],
 	"require": {
-		"php": ">=7.4",
+		"php": ">=8.3",
 		"ext-libxml": "*",
 		"erusev/parsedown": "1.8.0-beta-7",
-		"nikic/php-parser": "4.19.4",
+		"nikic/php-parser": "5.3.1",
 		"phpdocumentor/reflection-docblock": "5.5.1"
 	},
 	"require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
 	},
 	"require-dev": {
 		"oomphinc/composer-installers-extender": "^2",
-		"opis/json-schema": "^1"
+		"opis/json-schema": "2.3.0"
 	},
 	"funding": [
 		{

--- a/readme.md
+++ b/readme.md
@@ -6,6 +6,10 @@ Note: If you just want the hook files without generating them yourself, use the 
 
 * [wp-hooks/wordpress-core](https://github.com/wp-hooks/wordpress-core) for WordPress core
 
+## Requirements
+
+PHP 8.3 or higher.
+
 ## Installation
 
 ```shell

--- a/src/generate.php
+++ b/src/generate.php
@@ -323,9 +323,10 @@ function hooks_parse_files( array $files, string $root, array $ignore_hooks ) : 
 				$long = fix_newlines( (string) $db->getDescription() );
 				$markdown = \Parsedown::instance();
 				$html = $markdown->text((string) $db->getDescription());
+				$html = str_replace( "\n", ' ', $html );
 
 				$doc = [
-					'description' => $db->getSummary(),
+					'description' => str_replace( "\n", ' ', $db->getSummary() ),
 					'long_description' => $long,
 					'tags' => $tags,
 					'long_description_html' => $html,

--- a/src/generate.php
+++ b/src/generate.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace WPHooks\Generator;
 
 use DOMDocument;
-use phpDocumentor\Reflection\DocBlock;
 use phpDocumentor\Reflection\DocBlockFactory;
 use PhpParser\Node;
 use PhpParser\NodeTraverser;

--- a/src/generate.php
+++ b/src/generate.php
@@ -2,7 +2,7 @@
 <?php
 declare(strict_types=1);
 
-namespace JohnBillion\WPHooksGenerator;
+namespace WPHooks\Generator;
 
 use DOMDocument;
 use phpDocumentor\Reflection\DocBlock;

--- a/src/generate.php
+++ b/src/generate.php
@@ -256,6 +256,7 @@ function hooks_parse_files( array $files, string $root, array $ignore_hooks ) : 
 			];
 
 			$dbt = $docblock ? $docblock->getText() : '';
+			$aliases = null;
 
 			if ( !empty($dbt)) {
 				$dbf = DocBlockFactory::createInstance([
@@ -320,23 +321,32 @@ function hooks_parse_files( array $files, string $root, array $ignore_hooks ) : 
 
 				$long = fix_newlines( (string) $db->getDescription() );
 				$markdown = \Parsedown::instance();
+				$html = $markdown->text((string) $db->getDescription());
 
 				$doc = [
 					'description' => $db->getSummary(),
 					'long_description' => $long,
 					'tags' => $tags,
-					'long_description_html' => $markdown->text($long),
+					'long_description_html' => $html,
 				];
 
+				$aliases = parse_aliases( $html );
 			}
 
-			$output[] = [
-				'name' => $hook_name,
-				'file' => $relativename,
-				'type' => $funcNameStr === 'do_action' ? 'action' : 'filter',
-				'doc' => $doc,
-				'args' => count( $expr->args ) - 1,
-			];
+			$out = [];
+
+			$out['name'] = $hook_name;
+
+			if ( $aliases ) {
+				$out['aliases'] = $aliases;
+			}
+
+			$out['file'] = $relativename;
+			$out['type'] = $funcNameStr === 'do_action' ? 'action' : 'filter';
+			$out['doc'] = $doc;
+			$out['args'] = count( $expr->args ) - 1;
+
+			$output[] = $out;
 		}
 	}
 

--- a/src/generate.php
+++ b/src/generate.php
@@ -303,6 +303,7 @@ function hooks_parse_files( array $files, string $root, array $ignore_hooks ) : 
 							$tag_data['description'] = $description;
 						}
 					} elseif ( $tag instanceof \phpDocumentor\Reflection\DocBlock\Tags\Param ) {
+						$tag_data['types'] = explode( '|', (string) $tag->getType() );
 						$tag_data['variable'] = '$' . $tag->getVariableName();
 					} elseif ( $tag instanceof \phpDocumentor\Reflection\DocBlock\Tags\Link ) {
 						$tag_data['link'] = $tag->getLink();

--- a/src/generate.php
+++ b/src/generate.php
@@ -178,6 +178,13 @@ function hooks_parse_files( array $files, string $root, array $ignore_hooks ) : 
 
 	$tag_types = [];
 
+	$funcs = [
+		'do_action',
+		'apply_filters',
+		'do_action_ref_array',
+		'apply_filters_ref_array',
+	];
+
 	foreach ( $files as $filename ) {
 		// Parse the PHP file
 		$contents = file_get_contents($filename);
@@ -217,7 +224,7 @@ function hooks_parse_files( array $files, string $root, array $ignore_hooks ) : 
 
 			$funcNameStr = $funcName->toString();
 
-			if ($funcNameStr !== 'do_action' && $funcNameStr !== 'apply_filters') {
+			if ( ! in_array( $funcNameStr, $funcs, true ) ) {
 				continue;
 			}
 
@@ -343,7 +350,22 @@ function hooks_parse_files( array $files, string $root, array $ignore_hooks ) : 
 			}
 
 			$out['file'] = $relativename;
-			$out['type'] = $funcNameStr === 'do_action' ? 'action' : 'filter';
+
+			switch ( $funcNameStr ) {
+				case 'do_action':
+					$out['type'] = 'action';
+					break;
+				case 'apply_filters':
+					$out['type'] = 'filter';
+					break;
+				case 'do_action_ref_array':
+					$out['type'] = 'action_reference';
+					break;
+				case 'apply_filters_ref_array':
+					$out['type'] = 'filter_reference';
+					break;
+			}
+
 			$out['doc'] = $doc;
 			$out['args'] = count( $expr->args ) - 1;
 

--- a/src/generate.php
+++ b/src/generate.php
@@ -265,9 +265,7 @@ function hooks_parse_files( array $files, string $root, array $ignore_hooks ) : 
 			$aliases = null;
 
 			if ( !empty($dbt)) {
-				$dbf = DocBlockFactory::createInstance([
-					// 'since' => \phpDocumentor\Reflection\DocBlock\Tags\Since::class,
-				]);
+				$dbf = DocBlockFactory::createInstance();
 				$db = $dbf->create( $dbt );
 
 				$tags = [];
@@ -280,10 +278,6 @@ function hooks_parse_files( array $files, string $root, array $ignore_hooks ) : 
 					if ( ! method_exists( $tag, 'getVersion' ) && method_exists( $tag, 'getDescription' ) ) {
 						$content = (string) $tag->getDescription();
 						$content = preg_replace( '#\n\s+#', ' ', $content );
-					}
-
-					if ( empty( $content ) ) {
-						// continue;
 					}
 
 					$tag_data = [

--- a/src/generate.php
+++ b/src/generate.php
@@ -230,10 +230,6 @@ function hooks_parse_files( array $files, string $root, array $ignore_hooks ) : 
 
 			$hook = $expr->args[0];
 
-			if ( ! $hook instanceof Node\Arg ) {
-				continue;
-			}
-
 			$printer = new Standard();
 			$hook_name = $printer->prettyPrintExpr($hook->value);
 			$hook_name = preg_replace( '/^"(.*)"$/', '$1', $hook_name );

--- a/src/generate.php
+++ b/src/generate.php
@@ -344,13 +344,21 @@ function hooks_parse_files( array $files, string $root, array $ignore_hooks ) : 
 					$description = preg_replace( '/[\n\r]+/', ' ', strval( $tag->getDescription() ) );
 
 					if ( ! empty( $description ) ) {
-						$tag_data['description'] = $description;
+						$markdown = \Parsedown::instance();
+						$html = $markdown->text( $description );
+						$html = preg_replace( '/^<p>(.*)<\/p>$/', '$1', $html );
+						$tag_data['description'] = $html;
 					}
 				} elseif ( $tag instanceof \phpDocumentor\Reflection\DocBlock\Tags\Deprecated ) {
 					$tag_data['content'] = (string) $tag;
 				} elseif ( $tag instanceof \phpDocumentor\Reflection\DocBlock\Tags\Param ) {
 					$tag_data['types'] = explode( '|', (string) $tag->getType() );
 					$tag_data['variable'] = '$' . $tag->getVariableName();
+
+					$markdown = \Parsedown::instance();
+					$html = $markdown->text( $tag_data['content'] );
+					$html = preg_replace( '/^<p>(.*)<\/p>$/', '$1', $html );
+					$tag_data['content'] = $html;
 				} elseif ( $tag instanceof \phpDocumentor\Reflection\DocBlock\Tags\Link ) {
 					$link = $tag->getLink();
 					$tag_data['content'] = sprintf(
@@ -363,6 +371,10 @@ function hooks_parse_files( array $files, string $root, array $ignore_hooks ) : 
 					//
 				} elseif ( $tag instanceof \phpDocumentor\Reflection\DocBlock\Tags\See ) {
 					$tag_data['refers'] = ltrim( (string) $tag->getReference(), '\\' );
+					$markdown = \Parsedown::instance();
+					$html = $markdown->text( $tag_data['content'] );
+					$html = preg_replace( '/^<p>(.*)<\/p>$/', '$1', $html );
+					$tag_data['content'] = $html;
 				} elseif ( $tag instanceof \phpDocumentor\Reflection\DocBlock\Tags\InvalidTag && $tag->getName() === 'see' ) {
 					//
 				} elseif ( $tag instanceof \phpDocumentor\Reflection\DocBlock\Tags\Return_ ) {

--- a/src/generate.php
+++ b/src/generate.php
@@ -312,11 +312,17 @@ function hooks_parse_files( array $files, string $root, array $ignore_hooks ) : 
 						$tag_data['types'] = explode( '|', (string) $tag->getType() );
 						$tag_data['variable'] = '$' . $tag->getVariableName();
 					} elseif ( $tag instanceof \phpDocumentor\Reflection\DocBlock\Tags\Link ) {
-						$tag_data['link'] = $tag->getLink();
+						$link = $tag->getLink();
+						$tag_data['content'] = sprintf(
+							'<a href="%s">%s</a>',
+							$link,
+							$link
+						);
+						$tag_data['link'] = $link;
 					} elseif ( $tag instanceof \phpDocumentor\Reflection\DocBlock\Tags\Generic ) {
 						//
 					} elseif ( $tag instanceof \phpDocumentor\Reflection\DocBlock\Tags\See ) {
-						$tag_data['refers'] = $tag->getReference();
+						$tag_data['refers'] = (string) $tag->getReference();
 					} elseif ( $tag instanceof \phpDocumentor\Reflection\DocBlock\Tags\Deprecated ) {
 						//
 					} else {

--- a/src/generate.php
+++ b/src/generate.php
@@ -302,6 +302,8 @@ function hooks_parse_files( array $files, string $root, array $ignore_hooks ) : 
 						if ( ! empty( $description ) ) {
 							$tag_data['description'] = $description;
 						}
+					} elseif ( $tag instanceof \phpDocumentor\Reflection\DocBlock\Tags\Deprecated ) {
+						$tag_data['content'] = (string) $tag;
 					} elseif ( $tag instanceof \phpDocumentor\Reflection\DocBlock\Tags\Param ) {
 						$tag_data['types'] = explode( '|', (string) $tag->getType() );
 						$tag_data['variable'] = '$' . $tag->getVariableName();

--- a/src/generate.php
+++ b/src/generate.php
@@ -316,7 +316,7 @@ function hooks_parse_files( array $files, string $root, array $ignore_hooks ) : 
 					} elseif ( $tag instanceof \phpDocumentor\Reflection\DocBlock\Tags\Generic ) {
 						//
 					} elseif ( $tag instanceof \phpDocumentor\Reflection\DocBlock\Tags\See ) {
-						$tag_data['refers'] = (string) $tag->getReference();
+						$tag_data['refers'] = ltrim( (string) $tag->getReference(), '\\' );
 					} elseif ( $tag instanceof \phpDocumentor\Reflection\DocBlock\Tags\Deprecated ) {
 						//
 					} else {

--- a/src/validate.php
+++ b/src/validate.php
@@ -25,4 +25,5 @@ if ($result->isValid()) {
 	echo '$data is invalid', PHP_EOL;
 	echo "Error: ", $error->keyword(), PHP_EOL;
 	echo json_encode($error->keywordArgs(), JSON_PRETTY_PRINT), PHP_EOL;
+	exit(1);
 }

--- a/src/validate.php
+++ b/src/validate.php
@@ -6,24 +6,23 @@ namespace WPHooks\Generator;
 require_once file_exists( 'vendor/autoload.php' ) ? 'vendor/autoload.php' : dirname( __DIR__, 4 ) . '/vendor/autoload.php';
 
 use Opis\JsonSchema\{
-	Validator, ValidationResult, ValidationError, Schema
+	Validator,
+	Errors\ErrorFormatter,
 };
 
 $data = json_decode(file_get_contents( $argv[1] ));
-$schema = Schema::fromJsonString(file_get_contents('schema.json'));
-
 $validator = new Validator();
+$id = 'https://github.com/wp-hooks/generator/blob/0.9.0/schema.json';
+$validator->resolver()->registerFile(
+	$id,
+	'schema.json',
+);
 
-/** @var ValidationResult $result */
-$result = $validator->schemaValidation($data, $schema);
+$result = $validator->validate( $data, $id );
 
 if ($result->isValid()) {
-	echo '$data is valid', PHP_EOL;
+	echo 'Data is valid', PHP_EOL;
 } else {
-	/** @var ValidationError $error */
-	$error = $result->getFirstError();
-	echo '$data is invalid', PHP_EOL;
-	echo "Error: ", $error->keyword(), PHP_EOL;
-	echo json_encode($error->keywordArgs(), JSON_PRETTY_PRINT), PHP_EOL;
+	print_r( ( new ErrorFormatter() )->format($result->error() ) );
 	exit(1);
 }

--- a/src/validate.php
+++ b/src/validate.php
@@ -1,7 +1,7 @@
 #!/usr/bin/env php
 <?php
 
-namespace JohnBillion\WPHooksGenerator;
+namespace WPHooks\Generator;
 
 require_once file_exists( 'vendor/autoload.php' ) ? 'vendor/autoload.php' : dirname( __DIR__, 4 ) . '/vendor/autoload.php';
 


### PR DESCRIPTION
In order to extract the hooks information from files, this library uses [WP Parser Lib](https://github.com/wp-hooks/parser) which itself uses a very outdated version of `phpdocumentor/reflection` that doesn't support newer versions of PHP. It only really works fully on PHP 7.4. See https://github.com/WordPress/phpdoc-parser/issues/228 for details. 

Updating `phpdocumentor/reflection` in WP Parser Lib is proving to be a lot of effort. @otrocodigo has made a good effort in https://github.com/wp-hooks/parser/pull/1 but it's not yet complete and needs further updates in this library in order to support it.

I've also never been very happy with the depth of nested dependencies that result from this.

As an alternative approach, we can move the file parsing and hook extraction into this library and directly use `php-parser` to extract the hook information (`phpdocumentor/reflection` by default extracts a lot more info that we don't need). This simplifies the dependency tree and allows PHP 7.4 through 8.3 to be supported.