### PR TITLE
Namespaces, deprecated and scheduled hooks, performance,...

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -62,7 +62,9 @@
 							"action",
 							"filter",
 							"action_reference",
-							"filter_reference"
+							"filter_reference",
+                            "action_deprecated",
+                            "filter_deprecated"
 						]
 					},
 					"doc": {

--- a/src/generate.php
+++ b/src/generate.php
@@ -5,13 +5,33 @@ declare(strict_types=1);
 namespace WPHooks\Generator;
 
 use DOMDocument;
+use Exception;
+use Parsedown;
+use phpDocumentor\Reflection\DocBlock\Tags\Deprecated;
+use phpDocumentor\Reflection\DocBlock\Tags\Generic;
+use phpDocumentor\Reflection\DocBlock\Tags\InvalidTag;
+use phpDocumentor\Reflection\DocBlock\Tags\Link;
+use phpDocumentor\Reflection\DocBlock\Tags\Param;
+use phpDocumentor\Reflection\DocBlock\Tags\Return_;
+use phpDocumentor\Reflection\DocBlock\Tags\See;
+use phpDocumentor\Reflection\DocBlock\Tags\Since;
+use phpDocumentor\Reflection\DocBlock\Tags\Throws;
+use phpDocumentor\Reflection\DocBlock\Tags\Var_;
 use phpDocumentor\Reflection\DocBlockFactory;
+use phpDocumentor\Reflection\Types\Compound;
+use phpDocumentor\Reflection\Types\Context;
+use PhpParser;
 use PhpParser\Comment\Doc;
 use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\Variable;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\FindingVisitor;
 use PhpParser\ParserFactory;
 use PhpParser\PrettyPrinter\Standard;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use UnexpectedValueException;
 
 require_once file_exists( 'vendor/autoload.php' ) ? 'vendor/autoload.php' : dirname( __DIR__, 4 ) . '/vendor/autoload.php';
 
@@ -22,10 +42,13 @@ $options = getopt( '', [
 	"ignore-hooks::",
 ] );
 
-if ( empty( $options['input' ] ) || empty( $options['output'] ) ) {
-	printf(
-		"Usage: %s --input=src --output=hooks [--ignore-files=ignore/this,ignore/that] [--ignore-hooks=this_hook,that_hook] \n",
-		$argv[0]
+if ( empty( $options['input'] ) || empty( $options['output'] ) ) {
+	fwrite(
+		STDERR,
+		sprintf(
+			"Usage: %s --input=src --output=hooks [--ignore-files=ignore/this,ignore/that] [--ignore-hooks=this_hook,that_hook] \n",
+			$argv[0],
+		),
 	);
 	exit( 1 );
 }
@@ -59,7 +82,11 @@ if ( empty( $options['ignore-files'] ) ) {
 }
 
 if ( empty( $options['ignore-hooks'] ) ) {
-	$options['ignore-hooks'] = [];
+	$options['ignore-hooks'] = [
+		'autocomplete_users_for_site_admins',
+		'enable_edit_any_user_configuration',
+		'show_recent_comments_widget_style',
+	];
 }
 
 $source_dir = $options['input'];
@@ -68,17 +95,23 @@ $ignore_files = $options['ignore-files'];
 $ignore_hooks = $options['ignore-hooks'];
 
 if ( ! file_exists( $source_dir ) ) {
-	printf(
-		'The source directory "%s" does not exist.' . "\n",
-		$source_dir
+	fwrite(
+		STDERR,
+		sprintf(
+			"The source directory '%s' does not exist.\n",
+			$source_dir,
+		),
 	);
 	exit( 1 );
 }
 
 if ( ! file_exists( $target_dir ) ) {
-	printf(
-		'The target directory "%s" does not exist. Please create it first.' . "\n",
-		$target_dir
+	fwrite(
+		STDERR,
+		sprintf(
+			"The target directory '%s' does not exist. Please create it first.\n",
+			$target_dir,
+		),
 	);
 	exit( 1 );
 }
@@ -86,13 +119,11 @@ if ( ! file_exists( $target_dir ) ) {
 echo "Scanning for files...\n";
 
 /**
- * @param string $directory
- *
- * @return array|\WP_Error
+ * @return list<non-empty-string>
  */
-function get_wp_files( $directory ) {
-	$iterableFiles = new \RecursiveIteratorIterator(
-		new \RecursiveDirectoryIterator( $directory )
+function get_wp_files( string $directory, array $ignore_files ) {
+	$iterableFiles = new RecursiveIteratorIterator(
+		new RecursiveDirectoryIterator( $directory ),
 	);
 	$files = array();
 
@@ -101,23 +132,29 @@ function get_wp_files( $directory ) {
 			continue;
 		}
 
-		$files[] = $file->getPathname();
+		$file_path = $file->getPathname();
+		foreach ( $ignore_files as $key => $i ) {
+			if ( false === strpos( $file_path, $i ) ) {
+				continue;
+			}
+
+			// if we have a match, the next file will most likely also match this "ignore"
+			// prepend to speed up
+			if ( $key !== 0 ) {
+				unset( $ignore_files[ $key ] );
+				array_unshift( $ignore_files, $i );
+			}
+
+			continue 2;
+		}
+
+		$files[] = $file_path;
 	}
 
 	return $files;
 }
 
-/** @var array<int,string> */
-$files = get_wp_files( $source_dir );
-$files = array_values( array_filter( $files, function( string $file ) use ( $ignore_files ) : bool {
-	foreach ( $ignore_files as $i ) {
-		if ( false !== strpos( $file, $i ) ) {
-			return false;
-		}
-	}
-
-	return true;
-} ) );
+$files = get_wp_files( $source_dir, $ignore_files );
 
 printf(
 	"Found %d files. Parsing hooks...\n",
@@ -145,18 +182,18 @@ function fix_newlines( $text ) {
 
 	// Replace newline characters within 'code' and 'pre' tags with replacement string.
 	$text = preg_replace_callback(
-		"/(?<=<pre><code>)(.+)(?=<\/code><\/pre>)/s",
+		'/(?<=<pre><code>)(.+)(?=<\/code><\/pre>)/s',
 		function ( $matches ) use ( $replacement_string ) {
 			return preg_replace( '/[\n\r]/', $replacement_string, $matches[1] );
 		},
-		$text
+		$text,
 	);
 
 	// Merge consecutive non-blank lines together by replacing the newlines with a space.
 	$text = preg_replace(
 		"/[\n\r](?!\s*[\n\r])/m",
 		' ',
-		$text
+		$text,
 	);
 
 	// Restore newline characters into code blocks.
@@ -168,7 +205,7 @@ function fix_newlines( $text ) {
 class DocblockFinderVisitor extends FindingVisitor {
 	private ?Doc $latest_comment = null;
 
-	public function enterNode(Node $node) {
+	public function enterNode( Node $node ) {
 		$comment = $node->getDocComment();
 
 		if ( $comment ) {
@@ -176,9 +213,9 @@ class DocblockFinderVisitor extends FindingVisitor {
 		}
 
 		$filterCallback = $this->filterCallback;
-		if ($filterCallback($node)) {
+		if ( $filterCallback( $node ) ) {
 			if ( $this->latest_comment && $this->latest_comment->getEndLine() + 1 === $node->getStartLine() ) {
-				$node->setDocComment($this->latest_comment);
+				$node->setDocComment( $this->latest_comment );
 			}
 
 			$this->foundNodes[] = $node;
@@ -194,7 +231,7 @@ class DocblockFinderVisitor extends FindingVisitor {
  * @param array<int,string> $ignore_hooks
  * @return array
  */
-function hooks_parse_files( array $files, string $root, array $ignore_hooks ) : array {
+function hooks_parse_files( array $files, string $root, array $ignore_hooks ): array {
 	$output = array();
 
 	// Create a new parser instance
@@ -205,113 +242,228 @@ function hooks_parse_files( array $files, string $root, array $ignore_hooks ) : 
 		'apply_filters',
 		'do_action_ref_array',
 		'apply_filters_ref_array',
+		'do_action_deprecated',
+		'apply_filters_deprecated',
 	];
+
+	$event_functions = [
+		'wp_schedule_event',
+		// WooCommerce action scheduler
+		'as_schedule_recurring_action',
+		'as_schedule_cron_action',
+	];
+
+	$single_event_functions = [
+		'wp_schedule_single_event',
+		// WooCommerce action scheduler
+		'as_schedule_single_action',
+	];
+
+	$single_event_functions_no_timestamp = [
+		// WooCommerce action scheduler
+		'as_enqueue_async_action',
+	];
+
+	$single_event_functions = array_merge( $single_event_functions, $single_event_functions_no_timestamp );
+
+	$functions_regex = implode( '|', array_merge( $funcs, $event_functions, $single_event_functions ) );
 
 	foreach ( $files as $filename ) {
 		// Parse the PHP file
-		$contents = file_get_contents($filename);
+		$contents = file_get_contents( $filename );
 
-		if ($contents === false) {
-			throw new \Exception('Failed to read file ' . $filename);
+		if ( $contents === false ) {
+			throw new Exception( 'Failed to read file ' . $filename );
 		}
 
-		$stmts = $parser->parse($contents);
+		// if the file doesn't contain a relevant function we can skip it - reduces runtime massively
+		if ( preg_match( '/\b(?:' . $functions_regex . ')\s*\([^)]/', $contents ) === 0 ) {
+			continue;
+		}
 
-		if (!is_array($stmts)) {
-			throw new \Exception('Failed to parse file ' . $filename);
+		$stmts = $parser->parse( $contents );
+
+		if ( ! is_array( $stmts ) ) {
+			throw new Exception( 'Failed to parse file ' . $filename );
 		}
 
 		// Create a new FindingVisitor instance
 		$visitor = new DocblockFinderVisitor(
-			fn ( Node $node ) => ( $node instanceof Node\Expr\FuncCall )
+			fn ( Node $node ) => (
+				$node instanceof Node\Expr\FuncCall ||
+				$node instanceof Node\Stmt\Namespace_ ||
+				$node instanceof Node\Stmt\GroupUse ||
+				$node instanceof Node\Stmt\Use_
+			),
 		);
 
 		// Traverse the AST and resolve names
 		$traverser = new NodeTraverser();
 		$traverser->addVisitor( $visitor );
-		$traverser->traverse($stmts);
+		$traverser->traverse( $stmts );
 
-		/** @var array<Node\Expr\FuncCall> $found */
 		$found = $visitor->getFoundNodes();
 
-		// Process the parsed statements to find calls to do_action() and apply_filters()
-		foreach ( $found as $expr ) {
-			$funcName = $expr->name;
+		$namespace = '';
+		$use_statements = [];
+		$context = null;
 
-			if (! ($funcName instanceof Node\Name)) {
+		// Process the parsed statements to find calls to do_action() and apply_filters()
+		foreach ( $found as $node ) {
+			if ( $node instanceof Node\Stmt\Namespace_ ) {
+				// as soon as there is a new namespace, we need to empty the useStatements, as there will be new ones for the given namespace
+				if ( isset( $node->name ) ) {
+					$namespace = $node->name->toString();
+				} else {
+					// back to global namespace
+					$namespace = '';
+				}
+
+				$use_statements = [];
+				$context = null;
+				continue;
+			}
+
+			$fqcnPrefix = '';
+
+			// like "use superWC\special\{Order, Extra\Refund, User};"
+			if ( $node instanceof Node\Stmt\GroupUse ) {
+				// some have unnecessary leading \ in them, we need to remove first
+				// cannot be empty, as that is not valid in PHP GroupUse
+				// also directly add trailing backslash to simplify later processing
+				$fqcnPrefix = ltrim( $node->prefix->toString(), '\\' ) . '\\';
+			}
+
+			// normal "use" statements
+			// "use" for traits is a different class, so it will correctly not be handled here
+			// can still be multiple, e.g. "use Foo, Bar;"
+			// GroupUse can be processed the same way
+			if ( $node instanceof Node\Stmt\Use_ || $node instanceof Node\Stmt\GroupUse ) {
+				// constant and function "use" statements are irrelevant, we are only interested in class imports
+				if ( in_array( $node->type, array( 2, 3 ), true ) ) {
+					continue;
+				}
+
+				foreach ( $node->uses as $useObject ) {
+					if ( in_array( $node->type, array( 2, 3 ), true ) ) {
+						continue;
+					}
+
+					$fqcn = $useObject->name->toString();
+
+					// some have invalid leading \ in them, we need to remove first
+					$fqcn = $fqcnPrefix . ltrim( $fqcn, '\\' );
+
+					// technically not needed, since the namespace is included in the stubs
+					// changing it anyway, to make things easier to follow/read, as the stubs are a massive file usually
+					$fqcn = ltrim( preg_replace( '/^namespace\\\\/', addcslashes( $namespace . '\\', '\\' ), $fqcn, 1 ), '\\' );
+
+					// class names are unique, so we use them as keys of the array
+					if ( ! empty( $useObject->alias->name ) ) {
+						$use_statements[ $useObject->alias->name ] = $fqcn;
+					} else {
+						$use_statements[ $useObject->name->getLast() ] = $fqcn;
+					}
+				}
+
+				// we cannot skip children (UseItem), since it needs it to automatically adjust native type hints,... but we won't process it again for docblock
+				continue;
+			}
+
+			if ( ! $node instanceof Node\Expr\FuncCall ) {
+				continue;
+			}
+
+			$funcName = $node->name;
+
+			if ( ! ( $funcName instanceof Node\Name ) ) {
 				continue;
 			}
 
 			$funcNameStr = $funcName->toString();
 
-			if ( ! in_array( $funcNameStr, $funcs, true ) ) {
+			// similar code used in psalm-plugin-wordpress
+			$hook_index = 0;
+			$hook_type = false;
+			if ( in_array( $funcNameStr, $event_functions, true ) ) {
+				$hook_type = 'cron-action';
+				// the 3rd arg (index key 2) is the hook name
+				$hook_index = 2;
+			} elseif ( in_array( $funcNameStr, $single_event_functions, true ) ) {
+				$hook_type = 'cron-action';
+				$hook_index = 1;
+
+				if ( in_array( $funcNameStr, $single_event_functions_no_timestamp, true ) ) {
+					$hook_index = 0;
+				}
+			} elseif ( ! in_array( $funcNameStr, $funcs, true ) ) {
 				continue;
 			}
 
-			$docblock = $expr->getDocComment();
+			$docblock = $node->getDocComment();
 
-			if ( $docblock && str_starts_with($docblock->getText(), '/** This action is documented in') ) {
+			if ( $docblock && str_starts_with( $docblock->getText(), '/** This action is documented in' ) ) {
 				continue;
 			}
 
-			if ( $docblock && str_starts_with($docblock->getText(), '/** This filter is documented in') ) {
+			if ( $docblock && str_starts_with( $docblock->getText(), '/** This filter is documented in' ) ) {
+				continue;
+			}
+
+			$normalized_hook_name = get_formatted_hook_name( $node->args[ $hook_index ]->value );
+
+			if ( in_array( $normalized_hook_name, $ignore_hooks, true ) ) {
 				continue;
 			}
 
 			$printer = new Standard();
-			$hook_name = $printer->prettyPrintExpr( $expr->args[0]->value );
-			$hook_name = preg_replace( '/^"(.*)"$/', '$1', $hook_name );
-			$hook_name = preg_replace( "/^'(.*)'$/", '$1', $hook_name );
+			$hook_name = $printer->prettyPrintExpr( $node->args[ $hook_index ]->value );
+			$hook_name = preg_replace( '/^([\'"])(.*)\1$/', '$2', $hook_name, 1 );
 
-			if ( in_array( $hook_name, $ignore_hooks, true ) ) {
-				continue;
-			}
-
-			$known_problem_hooks = [
-				'autocomplete_users_for_site_admins',
-				'enable_edit_any_user_configuration',
-				'enqueue_block_assets',
-				'show_recent_comments_widget_style',
-			];
-
+			$dbt = '/** */';
 			if ( ! ( $docblock instanceof Doc ) ) {
-				echo sprintf(
-					"Hook '%s' in file '%s' is missing a docblock.\n",
-					$hook_name,
-					$filename,
-				);
-
-				continue;
-			}
-
-			$dbt = $docblock ? $docblock->getText() : '';
-
-			if ( empty( $dbt ) ) {
-				if ( in_array( $hook_name, $known_problem_hooks, true ) ) {
-					continue;
+				if ( $funcNameStr !== 'do_action' || count( $node->args ) > 1 ) {
+					fwrite(
+						STDERR,
+						sprintf(
+							"Hook '%s' in file '%s' is missing a docblock.\n",
+							$hook_name,
+							$filename,
+						),
+					);
 				}
-
-				echo sprintf(
-					"Hook '%s' in file '%s' has an empty docblock.\n",
-					$hook_name,
-					$filename,
+			} elseif ( $docblock->getText() === '' ) {
+				fwrite(
+					STDERR,
+					sprintf(
+						"Hook '%s' in file '%s' has an empty docblock.\n",
+						$hook_name,
+						$filename,
+					),
 				);
-
-				continue;
+			} else {
+				$dbt = $docblock->getText();
 			}
 
 			$doc = [
-				'description' => '',
-				'long_description' => '',
-				'tags' => [],
+				'description'           => '',
+				'long_description'      => '',
+				'tags'                  => [],
 				'long_description_html' => '',
 			];
 
+			if ( is_null( $context ) ) {
+				$context = new Context( $namespace, $use_statements );
+			}
+
 			$dbf = DocBlockFactory::createInstance();
-			$db = $dbf->create( $dbt );
-			$summary = trim( $db->getSummary() );
+			$db = $dbf->create( $dbt, $context );
+
+			// prevent leftover "/*" for docblocks like "/* */"
+			$summary = preg_replace( '#^/\*#', '', trim( $db->getSummary() ), 1 );
 			$tags = [];
 
+			$documented_params_count = 0;
 			foreach ( $db->getTags() as $tag ) {
 				$content = '';
 
@@ -321,14 +473,28 @@ function hooks_parse_files( array $files, string $root, array $ignore_hooks ) : 
 				}
 
 				$tag_data = [
-					'name' => $tag->getName(),
-					'content' => fix_newlines($content),
+					'name' => $tag instanceof Var_ || $tag instanceof Return_ ? 'param' : $tag->getName(),
+					'content' => fix_newlines( $content ),
 				];
 
-				if ( $tag instanceof \phpDocumentor\Reflection\DocBlock\Tags\InvalidTag && $tag->getName() === 'since' ) {
+				if ( $tag instanceof Return_ ) {
+					fwrite(
+						STDERR,
+						sprintf(
+							"Hook '%s' in file '%s' contains a @return tag, which is not supported.\n",
+							$hook_name,
+							$filename,
+						),
+					);
+				}
+
+				if ( $tag instanceof InvalidTag && $tag->getName() === 'since' ) {
 					$tag_data['content'] = (string) $tag;
-					$tag_data['description'] = (string) $tag;
-				} elseif ( $tag instanceof \phpDocumentor\Reflection\DocBlock\Tags\Since ) {
+					if ( $tag_data['content'] !== '' && str_contains( $tag_data['content'], ' ' ) ) {
+						$tag_data['description'] = ltrim( strstr( $tag_data['content'], ' ' ) );
+						$tag_data['content'] = strtok( $tag_data['content'], ' ' );
+					}
+				} elseif ( $tag instanceof Since ) {
 					// Version string.
 					$version = $tag->getVersion();
 
@@ -340,84 +506,136 @@ function hooks_parse_files( array $files, string $root, array $ignore_hooks ) : 
 					$description = preg_replace( '/[\n\r]+/', ' ', strval( $tag->getDescription() ) );
 
 					if ( ! empty( $description ) ) {
-						$markdown = \Parsedown::instance();
+						$markdown = Parsedown::instance();
 						$html = $markdown->text( $description );
 						$html = preg_replace( '/^<p>(.*)<\/p>$/', '$1', $html );
 						$tag_data['description'] = $html;
 					}
-				} elseif ( $tag instanceof \phpDocumentor\Reflection\DocBlock\Tags\Deprecated ) {
+				} elseif ( $tag instanceof Deprecated ) {
 					$tag_data['content'] = (string) $tag;
-				} elseif ( $tag instanceof \phpDocumentor\Reflection\DocBlock\Tags\Param ) {
-					$tag_data['types'] = explode( '|', (string) $tag->getType() );
-					$tag_data['variable'] = '$' . $tag->getVariableName();
+					if ( $tag_data['content'] !== '' && str_contains( $tag_data['content'], ' ' ) ) {
+						$tag_data['description'] = ltrim( strstr( $tag_data['content'], ' ' ) );
+						$tag_data['content'] = strtok( $tag_data['content'], ' ' );
+					}
+				} elseif (
+					$tag instanceof Param ||
+					$tag instanceof Var_ ||
+					(
+						$documented_params_count === 0 &&
+						$tag instanceof Return_
+					)
+				) {
+					++$documented_params_count;
 
-					$markdown = \Parsedown::instance();
+					$tag_data['types'] = [];
+					if ( $tag->getType() instanceof Compound ) {
+						foreach ( $tag->getType()->getIterator() as $type ) {
+							$tag_data['types'][] = (string) $type;
+						}
+					} else {
+						$tag_data['types'][] = (string) $tag->getType();
+					}
+
+					$tag_data['variable'] = $tag instanceof Return_ || $tag->getVariableName() === '' ? '' : '$' . $tag->getVariableName();
+
+
+					$markdown = Parsedown::instance();
 					$html = $markdown->text( $tag_data['content'] );
 					$html = preg_replace( '/^<p>(.*)<\/p>$/', '$1', $html );
 					$tag_data['content'] = $html;
-				} elseif ( $tag instanceof \phpDocumentor\Reflection\DocBlock\Tags\Link ) {
+				} elseif ( $tag instanceof Link ) {
 					$link = $tag->getLink();
 					$tag_data['content'] = sprintf(
 						'<a href="%s">%s</a>',
 						$link,
-						$link
+						$link,
 					);
 					$tag_data['link'] = $link;
-				} elseif ( $tag instanceof \phpDocumentor\Reflection\DocBlock\Tags\Generic ) {
+				} elseif ( $tag instanceof Generic ) {
 					//
-				} elseif ( $tag instanceof \phpDocumentor\Reflection\DocBlock\Tags\See ) {
+				} elseif ( $tag instanceof See ) {
 					$tag_data['refers'] = ltrim( (string) $tag->getReference(), '\\' );
-					$markdown = \Parsedown::instance();
+					$markdown = Parsedown::instance();
 					$html = $markdown->text( $tag_data['content'] );
 					$html = preg_replace( '/^<p>(.*)<\/p>$/', '$1', $html );
 					$tag_data['content'] = $html;
-				} elseif ( $tag instanceof \phpDocumentor\Reflection\DocBlock\Tags\InvalidTag && $tag->getName() === 'see' ) {
+				} elseif ( $tag instanceof InvalidTag && $tag->getName() === 'see' ) {
 					//
-				} elseif ( $tag instanceof \phpDocumentor\Reflection\DocBlock\Tags\Return_ ) {
-					printf(
-						'Hook "%s" contains a `@return` tag, which is not supported.' . "\n",
-						$hook_name,
+				} elseif ( $tag instanceof Throws ) {
+					//
+				} elseif ( $tag instanceof Return_ ) {
+					// don't add it either
+					continue;
+				} elseif (
+					$tag instanceof InvalidTag &&
+					$tag->getException() &&
+					get_class( $tag->getException() ) === 'InvalidArgumentException' &&
+					str_contains( $tag->getException()->getMessage(), 'Could not find type' )
+				) {
+					fwrite(
+						STDERR,
+						sprintf(
+							"%s for @%s for hook '%s' in file '%s'.\n",
+							$message,
+							$tag->getName(),
+							$hook_name,
+							$filename,
+						),
+					);
+
+					continue 2;
+				} elseif ( $tag instanceof InvalidTag && $tag->getException() ) {
+					throw new Exception(
+						sprintf(
+							'"%s" for @%s for hook "%s" in file "%s".',
+							$tag->getException()->getMessage(),
+							$tag->getName(),
+							$hook_name,
+							$filename,
+						),
+						$tag->getException()->getCode(),
+						$tag->getException(),
 					);
 				} else {
-					throw new \Exception(
+					throw new Exception(
 						sprintf(
 							'Unknown tag type "%s" (@%s) for hook "%s" in file "%s".',
 							get_class( $tag ),
 							$tag->getName(),
 							$hook_name,
 							$filename,
-						)
+						),
 					);
 				}
 
 				$tags[] = $tag_data;
 			}
 
-			$markdown = \Parsedown::instance();
-			$html = $markdown->text((string) $db->getDescription());
+			$markdown = Parsedown::instance();
+			$html = $markdown->text( (string) $db->getDescription() );
 			$html = str_replace( "\n", ' ', $html );
 			$long = fix_newlines( (string) $db->getDescription() );
 			$long = str_replace(
 				'  - ',
 				"\n  - ",
-				$long
+				$long,
 			);
 			$long = preg_replace_callback(
 				'# ([1-9])\. #',
-				static function( array $matches ) : string {
+				static function ( array $matches ): string {
 					return "\n {$matches[1]}. ";
 				},
-				$long
+				$long,
 			);
 			$doc = [
-				'description' => str_replace( "\n", ' ', $summary ),
-				'long_description' => $long,
-				'tags' => $tags,
+				'description'           => str_replace( "\n", ' ', $summary ),
+				'long_description'      => $long,
+				'tags'                  => $tags,
 				'long_description_html' => $html,
 			];
 			$out = [];
 
-			$out['name'] = $hook_name;
+			$out['name'] = $normalized_hook_name;
 
 			$aliases = parse_aliases( $html );
 
@@ -429,6 +647,7 @@ function hooks_parse_files( array $files, string $root, array $ignore_hooks ) : 
 
 			switch ( $funcNameStr ) {
 				case 'do_action':
+				default:
 					$out['type'] = 'action';
 					break;
 				case 'apply_filters':
@@ -440,16 +659,82 @@ function hooks_parse_files( array $files, string $root, array $ignore_hooks ) : 
 				case 'apply_filters_ref_array':
 					$out['type'] = 'filter_reference';
 					break;
+				case 'do_action_deprecated':
+					$out['type'] = 'action_deprecated';
+					break;
+				case 'apply_filters_deprecated':
+					$out['type'] = 'filter_deprecated';
+					break;
 			}
 
 			$out['doc'] = $doc;
-			$out['args'] = count( $expr->args ) - 1;
+
+			// we cannot count( $node->args ) - 1, since this is wrong for do_action_ref_array or cron actions in all cases except where the array literally has 1 element
+			if ( $documented_params_count > 0 ) {
+				$out['args'] = $documented_params_count;
+
+				// only possible for cases where the args are not passed as a single array
+				$expect_params = count( $node->args ) - $hook_index - 1;
+				if (
+					in_array( $funcNameStr, [ 'do_action', 'apply_filters' ] ) &&
+					$documented_params_count !== count( $node->args ) - $hook_index - 1
+				) {
+					fwrite(
+						STDERR,
+						sprintf(
+							"Hook '%s' in file '%s' has %d documented params, but %d params found.\n",
+							$hook_name,
+							$filename,
+							$documented_params_count,
+							$expect_params,
+						),
+					);
+				}
+			} elseif ( in_array( $funcNameStr, [ 'do_action', 'apply_filters' ] ) ) {
+				$out['args'] = count( $node->args ) - 1;
+			} elseif (
+				isset( $node->args[ $hook_index + 1 ] )
+				&& $node->args[ $hook_index + 1 ] instanceof PhpParser\Node\Arg &&
+				$node->args[ $hook_index + 1 ]->value instanceof PhpParser\Node\Expr\Array_
+			) {
+				$out['args'] = count( $node->args[ $hook_index + 1 ]->value->items );
+
+				// we could possibly static analysis infer the types here like in psalm-plugin-wordpress, however it's usually worse, since we only check 1 file and have less type info
+				// better to infer it directly in psalm if needed at all
+			} elseif ( ! isset( $node->args[ $hook_index + 1 ] ) ) {
+				$out['args'] = 0;
+			} else {
+				// if we want to be absolutely safe, it should be 0, however in 99% of cases it does not make sense for these to not have any argument
+				$out['args'] = 1;
+			}
+
+			// only if we didn't already report an error for empty/missing docblock
+			if ( $dbt !== '/** */' && $out['args'] !== 0 && $documented_params_count === 0 ) {
+				fwrite(
+					STDERR,
+					sprintf(
+						"Hook '%s' in file '%s' is missing @param for all arguments.\n",
+						$hook_name,
+						$filename,
+					),
+				);
+			}
+
+			// ignore fully dynamic, generic hooks too, since there's no useful info to be gained from them
+			// only down here, since we still want to get errors reported for it
+			if ( $normalized_hook_name === '{$var}' ) {
+				continue;
+			}
 
 			$output[] = $out;
 		}
 	}
 
-	usort( $output, function( array $a, array $b ) : int {
+	usort( $output, function ( array $a, array $b ): int {
+		if ( $a['name'] === $b['name'] ) {
+			return strlen( $a['file'] ) - strlen( $b['file'] );
+		}
+
 		return strcmp( $a['name'], $b['name'] );
 	} );
 
@@ -459,7 +744,7 @@ function hooks_parse_files( array $files, string $root, array $ignore_hooks ) : 
 /**
  * @return array<int, string>
  */
-function parse_aliases( string $html ) : array {
+function parse_aliases( string $html ): array {
 	if ( false === strpos( $html, 'Possible hook names include' ) ) {
 		return [];
 	}
@@ -485,7 +770,7 @@ $output = hooks_parse_files( $files, $source_dir, $ignore_hooks );
 
 // Actions
 $actions = array_values( array_filter( $output, function( array $hook ) : bool {
-	return in_array( $hook['type'], [ 'action', 'action_reference' ], true );
+	return in_array( $hook['type'], [ 'action', 'action_reference', 'action_deprecated' ], true );
 } ) );
 
 $actions = [
@@ -497,7 +782,7 @@ $result = file_put_contents( $target_dir . '/actions.json', json_encode( $action
 
 // Filters
 $filters = array_values( array_filter( $output, function( array $hook ) : bool {
-	return in_array( $hook['type'], [ 'filter', 'filter_reference' ], true );
+	return in_array( $hook['type'], [ 'filter', 'filter_reference', 'filter_deprecated' ], true );
 } ) );
 
 $filters = [
@@ -508,3 +793,117 @@ $filters = [
 $result = file_put_contents( $target_dir . '/filters.json', json_encode( $filters, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
 
 echo "Done\n";
+
+/**
+ * recreate the original hooks format used by wp-parser-lib
+ * see psalm-plugin-wordpress Plugin::getDynamicHookName())
+ */
+function get_formatted_hook_name( object $arg, bool $keep_var_name = false ): string {
+	// variable or 'foo' . $bar variable hook name
+	// "foo_{$my_var}_bar" is the wp-hooks-generator style, we need to mimic
+	if ( $arg instanceof PhpParser\Node\Expr\Variable ) {
+		if ( $keep_var_name === false ) {
+			// avoid false positive errors caused by just a variable, since it's too generic
+			// this is filtered out later on
+			return '{$var}';
+		}
+
+		return '{$' . $arg->name . '}';
+	}
+
+	if ( $arg instanceof PhpParser\Node\Scalar\Encapsed || $arg instanceof PhpParser\Node\Scalar\InterpolatedString ) {
+		$hook_name = '';
+		foreach ( $arg->parts as $part ) {
+			$hook_name .= get_formatted_hook_name( $part, true );
+		}
+
+		return $hook_name;
+	}
+
+	if ( $arg instanceof PhpParser\Node\Expr\BinaryOp\Concat ) {
+		$hook_name = get_formatted_hook_name( $arg->left, true );
+		$hook_name .= get_formatted_hook_name( $arg->right, true );
+
+		return $hook_name;
+	}
+
+	if ( $arg instanceof PhpParser\Node\Scalar\String_ || $arg instanceof PhpParser\Node\Scalar\EncapsedStringPart || $arg instanceof PhpParser\Node\InterpolatedStringPart || $arg instanceof PhpParser\Node\Scalar\LNumber || $arg instanceof PhpParser\Node\Scalar\Int_ ) {
+		return $arg->value;
+	}
+
+	if ( $arg instanceof PhpParser\Node\Scalar\MagicConst\Function_ ) {
+		// __FUNCTION__
+		return '{$var}';
+	}
+
+	if ( $arg instanceof PhpParser\Node\Expr\StaticPropertyFetch ) {
+		// e.g. self::$foo
+		if ( $arg->class instanceof PhpParser\Node\Name ) {
+			$class_name = $arg->class->name;
+		} else {
+			$class_name = trim( get_formatted_hook_name( $arg->class, true ), '{}' );
+		}
+
+		return '{' . $class_name . '::$' . $arg->name->toString() . '}';
+	}
+
+	if ( $arg instanceof PhpParser\Node\Expr\StaticCall || $arg instanceof PhpParser\Node\Expr\ClassConstFetch ) {
+		if ( ! $arg->name instanceof PhpParser\Node\Identifier ) {
+			throw new UnexpectedValueException( 'Unsupported dynamic hook name with name type ' . get_class( $arg->name ) . ' on line ' . $arg->getStartLine(), 0 );
+		}
+
+		// hook name with Foo::bar()
+		if ( $arg->class instanceof PhpParser\Node\Name ) {
+			$class_name = $arg->class->name;
+		} else {
+			$class_name = trim( get_formatted_hook_name( $arg->class, true ), '{}' );
+		}
+
+		$append_method_call = $arg instanceof PhpParser\Node\Expr\StaticCall ? '()' : '';
+
+		return '{' . $class_name . '::' . $arg->name->toString() . $append_method_call . '}';
+	}
+
+	if ( $arg instanceof PhpParser\Node\Expr\PropertyFetch || $arg instanceof PhpParser\Node\Expr\MethodCall ) {
+		if ( ! $arg->name instanceof PhpParser\Node\Identifier ) {
+			throw new UnexpectedValueException( 'Unsupported dynamic hook name with name type ' . get_class( $arg->name ) . ' on line ' . $arg->getStartLine(), 0 );
+		}
+
+		// need to check recursively
+		$temp = get_formatted_hook_name( $arg->var, true );
+
+		$append_method_call = $arg instanceof PhpParser\Node\Expr\MethodCall ? '()' : '';
+
+		return rtrim( $temp, '}' ) . '->' . $arg->name->toString() . $append_method_call . '}';
+	}
+
+	if ( $arg instanceof PhpParser\Node\Expr\FuncCall ) {
+		// mostly relevant for add_action - can just assume any variable name without using the function name, since it's useless (e.g. basename, dirname,... are common ones)
+		return '{$var}';
+	}
+
+	if ( $arg instanceof PhpParser\Node\Expr\ArrayDimFetch ) {
+		$key_hook_name = get_formatted_hook_name( $arg->dim, true );
+
+		// need to check recursively
+		$temp = get_formatted_hook_name( $arg->var, true );
+
+		if ( $key_hook_name[0] === '{' ) {
+			$key = trim( $key_hook_name, '{}' );
+		} elseif ( is_numeric( $key_hook_name ) ) {
+			$key = $key_hook_name;
+		} else {
+			$key = "'" . $key_hook_name . "'";
+		}
+
+		return rtrim( $temp, '}' ) . '[' . $key . ']}';
+	}
+
+	if ( $arg instanceof PhpParser\Node\Expr\ConstFetch ) {
+		return '{$var}';
+	}
+
+	// other types not supported yet
+	// add handling if encountered
+	throw new UnexpectedValueException( 'Unsupported dynamic hook name with type ' . get_class( $arg ) . ' on line ' . $arg->getStartLine(), 0 );
+}


### PR DESCRIPTION
Sorry for this massive PR, I initially intended to submit it separately, but then more and more changes accumulated as we used it internally and I never found the time to PR it.
Before these fixes might never get upstreamed/lost, I thought I PR most of it now at once. (the biggest code chunks added are just copies (with slight updates) of what I implemented in either psalm-plugin-wordpress or php stubs-generator packages already a long time ago)

Fix https://github.com/wp-hooks/generator/issues/17 
Add full support for namespaces and use statements 
Fix https://github.com/wp-hooks/generator/issues/9 (replaces https://github.com/wp-hooks/generator/pull/11) 
Add (back/again?) deprecated hooks
Restore dynamic hook name printing as it was pre <1.0.0, since the format was more useful/general - reused my code of psalm/psalm-plugin-wordpress (atm it's slightly different there bc I didn't have time to update it yet) 
Massively speed up processing by skipping ignored files earlier (mostly relevant for plugins) 
Speed up processing by skipping files that do not contain any filters/actions (mostly relevant for plugins) 
Restore error output to stderr instead of stdout which I previously already fix in <1.0.0 and consistently write errors to stderr everywhere 
Exclude fully dynamic, variable only hooks, since they only lead to false positive in tooling (aligns with psalm-plugin-wordpress) Add additional errors
Use @return as param if it's the only annotated tag 
Various code style fix to make more aligned with WP code style
Fix https://github.com/wp-hooks/generator/issues/22